### PR TITLE
Fix the syntax of the `should_panic` attribute

### DIFF
--- a/tests/integration1.rs
+++ b/tests/integration1.rs
@@ -100,7 +100,7 @@ fn test_echo_server_performance() {
 
 // this test should panic
 #[test]
-#[should_panic()]
+#[should_panic]
 fn test_reactor_outside_runtime() {
     fuchu::reactor();
 }


### PR DESCRIPTION
Hi there!

The Rust compiler accidentally accepted certain invalid forms of the should_panic attribute.
This is being fixed in this change to the Rust compiler: https://github.com/rust-lang/rust/pull/143808
Because the change will break this project, I'm submitting a fix PR as a courtesy, this should make sure your project continues to build correctly on new versions of Rust